### PR TITLE
fix: Fix serialization errors for Enums

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,8 @@ updates:
     directories:
       - "/.github/workflows"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      workflow-hub-updates:
+        patterns:
+          - "netcracker/qubership-workflow-hub/*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/community/" >/etc/apk/repo
             jq=1.8.1-r0 \
             libpng=1.6.58-r1 \
             libcrypto3=3.5.7-r0 \
-            libexpat=2.7.5-r0 \
+            libexpat=2.8.1-r0 \
             libssl3=3.5.7-r0 \
             musl=1.2.5-r23 \
             musl-utils=1.2.5-r23 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/community/" >/etc/apk/repo
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/main/" >>/etc/apk/repositories && \
     apk add --update --no-cache --no-check-certificate \
             bash=5.3.3-r1 \
-            curl=8.19.0-r0 \
+            curl=8.20.0-r0 \
             font-dejavu=2.37-r6 \
             fontconfig=2.17.1-r0 \
             gcompat=1.1.0-r4 \

--- a/qubership-atp-ram/qubership-atp-ram-model/src/main/java/org/qubership/atp/ram/enums/TestScopeSections.java
+++ b/qubership-atp-ram/qubership-atp-ram-model/src/main/java/org/qubership/atp/ram/enums/TestScopeSections.java
@@ -16,11 +16,13 @@
 
 package org.qubership.atp.ram.enums;
 
+import java.io.Serializable;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public enum TestScopeSections {
+public enum TestScopeSections implements Serializable {
     PREREQUISITES("Prerequisites"),
     EXECUTION("Execution"),
     VALIDATION("Validation");

--- a/qubership-atp-ram/qubership-atp-ram-model/src/main/java/org/qubership/atp/ram/enums/TestingStatuses.java
+++ b/qubership-atp-ram/qubership-atp-ram-model/src/main/java/org/qubership/atp/ram/enums/TestingStatuses.java
@@ -16,10 +16,12 @@
 
 package org.qubership.atp.ram.enums;
 
+import java.io.Serializable;
+
 import lombok.Getter;
 
 @Getter
-public enum TestingStatuses {
+public enum TestingStatuses implements Serializable {
 
     STOPPED("Stopped", 5, 6),
     FAILED("Failed", 4, 3),
@@ -30,9 +32,9 @@ public enum TestingStatuses {
     NOT_STARTED("Not Started", 1, 7),
     UNKNOWN("Unknown", 0, 8);
 
-    private String name;
-    private int id;
-    private int reportsOrder;
+    private final String name;
+    private final int id;
+    private final int reportsOrder;
 
     TestingStatuses(String name, int id, int reportsOrder) {
         this.name = name;


### PR DESCRIPTION

<!-- start messages -->
### Commit messages:
[kagw95](https://github.com/Netcracker/qubership-testing-platform-ram/commit/a9fd010f4a2b175ac7eac06728f3bb2746023f6e) fix: Add Serializable to enums to avoid HazelCast serialization exceptions.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-ram/commit/fa53305b1ba20ad26af821091eca1f654837c3d8) fix(deps): Bump APK libexpat to 2.8.1-r0.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-ram/commit/c30cfbd566e826b11b26433c0451acab9062e1a7) chore: Change Dependabot config to group updates from qubership-workflow-hub repository.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-ram/commit/0fabc81cecbe02b6d667d4eaa88d0c3ea221b867) fix(deps): Bump APK curl to 8.20.0-r0.
<!-- end messages -->
